### PR TITLE
remove duplicated clause line

### DIFF
--- a/lib/cbor/decoder.ex
+++ b/lib/cbor/decoder.ex
@@ -72,8 +72,6 @@ defmodule Cbor.Decoder do
 
   def read_unsigned_integer(value) do
     case value do
-      << 26::size(5), value::size(32), rest::bits >> ->
-        {value, rest}
       << 27::size(5), value::size(64), rest::bits >> ->
         {value, rest}
       << 26::size(5), value::size(32), rest::bits >> ->


### PR DESCRIPTION
I remove duplicated line for following warning.

```
warning: this clause cannot match because a previous clause at line 75 always matches
  lib/cbor/decoder.ex:79
```