### PR TITLE
Support negative integer and fix threshold for unsigned int

### DIFF
--- a/lib/cbor/decoder.ex
+++ b/lib/cbor/decoder.ex
@@ -1,5 +1,6 @@
 defmodule Cbor.Decoder do
   @unsigned_integer Cbor.Types.unsigned_integer()
+  @negative_integer Cbor.Types.negative_integer()
   @string Cbor.Types.string()
   @array Cbor.Types.array()
   @byte_string Cbor.Types.byte_string()
@@ -19,6 +20,8 @@ defmodule Cbor.Decoder do
     case value do
       << @unsigned_integer, bits::bits >> ->
         read_unsigned_integer(bits)
+      << @negative_integer, bits::bits >> ->
+        read_negative_integer(bits)
       << @string, bits::bits >> ->
         read_string(bits)
       << @byte_string, bits::bits >> ->
@@ -86,4 +89,22 @@ defmodule Cbor.Decoder do
         {value, rest}
     end
   end
+
+  def read_negative_integer(value) do
+    case value do
+      << 27::size(5), unsigned_value::size(64), rest::bits >> ->
+        {unsiged_to_negative(unsigned_value), rest}
+      << 26::size(5), unsigned_value::size(32), rest::bits >> ->
+        {unsiged_to_negative(unsigned_value), rest}
+      << 25::size(5), unsigned_value::size(16), rest::bits >> ->
+        {unsiged_to_negative(unsigned_value), rest}
+      << 24::size(5), unsigned_value::size(8), rest::bits >> ->
+        {unsiged_to_negative(unsigned_value), rest}
+      << <<unsigned_value::size(5)>>::bitstring, rest::bits >> ->
+        {unsiged_to_negative(unsigned_value), rest}
+    end
+  end
+
+  defp unsiged_to_negative(unsined_value), do: (unsined_value + 1) * -1
+
 end

--- a/lib/cbor/types.ex
+++ b/lib/cbor/types.ex
@@ -1,11 +1,13 @@
 defmodule Cbor.Types do
   @unsigned_integer <<0b000::3>>
+  @negative_integer <<0b001::3>>
   @byte_string <<0b010::3>>
   @string <<0b011::3>>
   @map <<0b101::3>>
   @array <<0b100::3>>
 
   def unsigned_integer, do: @unsigned_integer
+  def negative_integer, do: @negative_integer
   def byte_string, do: @byte_string
   def string, do: @string
   def map, do: @map

--- a/test/cbor_test.exs
+++ b/test/cbor_test.exs
@@ -11,7 +11,19 @@ defmodule CborTest do
     round_trip(65535)
     round_trip(65536)
     round_trip(4_294_967_295)
+    round_trip(4_294_967_296)
     round_trip(18_446_744_073_709_551_615)
+
+    assert Cbor.encode(0) == <<0>>
+    assert Cbor.encode(23) == <<23>>
+    assert Cbor.encode(24) == <<24, 24>>
+    assert Cbor.encode(255) == <<24, 255>>
+    assert Cbor.encode(256) == <<25, 1, 0>>
+    assert Cbor.encode(65535) == <<25, 255, 255>>
+    assert Cbor.encode(65536) == <<26, 0, 1, 0, 0>>
+    assert Cbor.encode(4_294_967_295) == <<26, 255, 255, 255, 255>>
+    assert Cbor.encode(4_294_967_296) == <<27, 0, 0, 0, 1, 0, 0, 0, 0>>
+    assert Cbor.encode(18_446_744_073_709_551_615) == <<27, 255, 255, 255, 255, 255, 255, 255, 255>>
   end
 
   test "negative integers" do
@@ -24,6 +36,17 @@ defmodule CborTest do
     round_trip(-65537)
     round_trip(-4_294_967_296)
     round_trip(-18_446_744_073_709_551_616)
+
+    assert Cbor.encode(-1) == <<32>>
+    assert Cbor.encode(-24) == <<55>>
+    assert Cbor.encode(-25) == <<56, 24>>
+    assert Cbor.encode(-256) == <<56, 255>>
+    assert Cbor.encode(-257) == <<57, 1, 0>>
+    assert Cbor.encode(-65536) == <<57, 255, 255>>
+    assert Cbor.encode(-65537) == <<58, 0, 1, 0, 0>>
+    assert Cbor.encode(-4_294_967_296) == <<58, 255, 255, 255, 255>>
+    assert Cbor.encode(-4_294_967_297) == <<59, 0, 0, 0, 1, 0, 0, 0, 0>>
+    assert Cbor.encode(-18_446_744_073_709_551_616) == <<59, 255, 255, 255, 255, 255, 255, 255, 255>>
   end
 
   test "strings (symbols)" do

--- a/test/cbor_test.exs
+++ b/test/cbor_test.exs
@@ -3,9 +3,27 @@ defmodule CborTest do
   doctest Cbor
 
   test "unsigned integers" do
-    round_trip(1)
+    round_trip(0)
+    round_trip(23)
     round_trip(24)
-    round_trip(42)
+    round_trip(255)
+    round_trip(256)
+    round_trip(65535)
+    round_trip(65536)
+    round_trip(4_294_967_295)
+    round_trip(18_446_744_073_709_551_615)
+  end
+
+  test "negative integers" do
+    round_trip(-1)
+    round_trip(-24)
+    round_trip(-25)
+    round_trip(-256)
+    round_trip(-257)
+    round_trip(-65536)
+    round_trip(-65537)
+    round_trip(-4_294_967_296)
+    round_trip(-18_446_744_073_709_551_616)
   end
 
   test "strings (symbols)" do


### PR DESCRIPTION
I added some functions for negative integers.
At that time, I found that the integer representation threshold is incorrect. and I fixed it.